### PR TITLE
Update Utilities.swift

### DIFF
--- a/Source/Supporting Files/Utilities.swift
+++ b/Source/Supporting Files/Utilities.swift
@@ -26,7 +26,8 @@ internal let NotificationCenter = NSNotificationCenter.defaultCenter()
 
 extension UIApplication {
     var rootViewController: UIViewController? {
-        return delegate?.window??.rootViewController
+        let root = delegate?.window??.rootViewController
+        return root?.presentedViewController ?? root // Handle presenting an alert over a modal screen
     }
 }
 


### PR DESCRIPTION
DisabledAlert and DeniedAlert fail to show when there is a presented VC displayed (aka modal VC). 

Console : Warning: Attempt to present <UIAlertController: 0x7f8cf384e950> on <UITabBarController: 0x7f8ce8532ea0> whose view is not in the window hierarchy!

When presenting an alert, we need to test for rootVC.presentedViewControllerC, and fallback to rootVC if needed
