### PR TITLE
[Location] Listen to location permission changes always

### DIFF
--- a/Source/PermissionTypes/Location.swift
+++ b/Source/PermissionTypes/Location.swift
@@ -33,8 +33,6 @@ extension Permission: CLLocationManagerDelegate {
 
 extension CLLocationManager {
     func request(permission: Permission) {
-        delegate = permission
-        
         switch permission.type {
         case .LocationAlways: requestAlwaysAuthorization()
         case .LocationWhenInUse: requestWhenInUseAuthorization()

--- a/Source/PermissionTypes/LocationAlways.swift
+++ b/Source/PermissionTypes/LocationAlways.swift
@@ -30,6 +30,8 @@ internal extension Permission {
     var statusLocationAlways: PermissionStatus {
         guard CLLocationManager.locationServicesEnabled() else { return .Disabled }
         
+        LocationManager.delegate = self
+        
         let status = CLLocationManager.authorizationStatus()
         
         switch status {

--- a/Source/PermissionTypes/LocationWhenInUse.swift
+++ b/Source/PermissionTypes/LocationWhenInUse.swift
@@ -28,6 +28,8 @@ internal extension Permission {
     var statusLocationWhenInUse: PermissionStatus {
         guard CLLocationManager.locationServicesEnabled() else { return .Disabled }
         
+        LocationManager.delegate = self
+        
         let status = CLLocationManager.authorizationStatus()
         
         switch status {


### PR DESCRIPTION
Hey Damien!

I've noticed stranger behaviour. When you request your Location for the first time, the notifications with status of permission is followed (so when you change from authorized to denied, the closure still updates for each change of permission). 

I don't know if it was intended or not, but in this PR I think I've solved this problem, even though I don't know if this is the good way to go. With these small changes I'm getting Location permission updates even after relaunching the app with e.g. Authorized status. When I go back to settings and change it, then come back to app, it works as I expected.

Let me know what do you think about it and thanks again for great lib! 🎉
