### PR TITLE
Add AddressBook Type separately from Contacts

### DIFF
--- a/Permission.xcodeproj/project.pbxproj
+++ b/Permission.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6C04FAF61CCA8F3A00B3F361 /* AddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C04FAF51CCA8F3A00B3F361 /* AddressBook.swift */; };
 		6D0069B41C1868E8002FDB42 /* PermissionSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D0069B31C1868E8002FDB42 /* PermissionSet.swift */; };
 		6D0EBDBD1BFCF8B700C35F8E /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D0EBDBC1BFCF8B700C35F8E /* Utilities.swift */; };
 		6D491E761C9CA7DE00611006 /* PermissionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D491E751C9CA7DE00611006 /* PermissionType.swift */; };
@@ -42,6 +43,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6C04FAF51CCA8F3A00B3F361 /* AddressBook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBook.swift; sourceTree = "<group>"; };
 		6D0069B31C1868E8002FDB42 /* PermissionSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionSet.swift; sourceTree = "<group>"; };
 		6D0EBDBC1BFCF8B700C35F8E /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
 		6D491E751C9CA7DE00611006 /* PermissionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionType.swift; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 		6DF9C2B01C8F4F30000710C1 /* PermissionTypes */ = {
 			isa = PBXGroup;
 			children = (
+				6C04FAF51CCA8F3A00B3F361 /* AddressBook.swift */,
 				6D935F5C1C9A0FEA00BB39E3 /* Bluetooth.swift */,
 				6DF9C2BB1C8F4FDA000710C1 /* Camera.swift */,
 				6DF9C2AE1C8F4F2A000710C1 /* Contacts.swift */,
@@ -288,6 +291,7 @@
 				6DF9C2AF1C8F4F2A000710C1 /* Contacts.swift in Sources */,
 				6DF9C2C61C8F5B4C000710C1 /* Location.swift in Sources */,
 				6DA8B4B21BFB8AD8007A94FC /* PermissionAlert.swift in Sources */,
+				6C04FAF61CCA8F3A00B3F361 /* AddressBook.swift in Sources */,
 				6DF9C2BE1C8F4FE5000710C1 /* Photos.swift in Sources */,
 				6DF9C2BA1C8F4FAC000710C1 /* Microphone.swift in Sources */,
 				6DF9C2BC1C8F4FDA000710C1 /* Camera.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ permission.request { status in
 > [`PermissionType.swift`](https://github.com/delba/Permission/blob/master/Source/PermissionType.swift)
 > [`PermissionTypes/`](https://github.com/delba/Permission/tree/master/Source/PermissionTypes)
 
+- [`AddressBook`](https://github.com/delba/Permission/blob/master/Source/PermissionTypes/AddressBook.swift) (Deprecated in iOS 9.0)
 - [`Bluetooth`](https://github.com/delba/Permission/blob/master/Source/PermissionTypes/Bluetooth.swift)
 - [`Camera`](https://github.com/delba/Permission/blob/master/Source/PermissionTypes/Camera.swift)
 - [`Contacts`](https://github.com/delba/Permission/blob/master/Source/PermissionTypes/Contacts.swift)

--- a/Source/Permission.swift
+++ b/Source/Permission.swift
@@ -28,6 +28,9 @@ public class Permission: NSObject {
     /// The permission to access the user's contacts.
     public static let Contacts = Permission(.Contacts)
     
+    /// The permission to access the user's address book. (Deprecated in iOS 9.0)
+    public static let AddressBook = Permission(.AddressBook)
+    
     /// The permission to access the user's location when the app is in background.
     public static let LocationAlways = Permission(.LocationAlways)
     
@@ -70,6 +73,7 @@ public class Permission: NSObject {
     public var status: PermissionStatus {
         switch type {
         case .Contacts:          return statusContacts
+        case .AddressBook:       return statusAddressBook
         case .LocationAlways:    return statusLocationAlways
         case .LocationWhenInUse: return statusLocationWhenInUse
         case .Notifications:     return statusNotifications
@@ -145,6 +149,7 @@ public class Permission: NSObject {
     internal func requestAuthorization(callback: Callback) {
         switch type {
         case .Contacts:          requestContacts(callback)
+        case .AddressBook:       requestAddressBook(callback)
         case .LocationAlways:    requestLocationAlways(callback)
         case .LocationWhenInUse: requestLocationWhenInUse(callback)
         case .Notifications:     requestNotifications(callback)

--- a/Source/Permission.swift
+++ b/Source/Permission.swift
@@ -26,6 +26,7 @@ public class Permission: NSObject {
     public typealias Callback = PermissionStatus -> Void
 
     /// The permission to access the user's contacts.
+    @available(iOS 9.0, *)
     public static let Contacts = Permission(.Contacts)
     
     /// The permission to access the user's address book. (Deprecated in iOS 9.0)

--- a/Source/PermissionType.swift
+++ b/Source/PermissionType.swift
@@ -23,7 +23,7 @@
 //
 
 public enum PermissionType {
-    case Contacts
+    @available(iOS 9.0, *) case Contacts
     case AddressBook // Deprecated in iOS 9.0
     case LocationAlways
     case LocationWhenInUse

--- a/Source/PermissionTypes/AddressBook.swift
+++ b/Source/PermissionTypes/AddressBook.swift
@@ -1,7 +1,7 @@
 //
-//  PermissionType.swift
+//  AddressBook.swift
 //
-//  Copyright (c) 2015 Damien (http://delba.io)
+//  Copyright (c) 2016 Damien (http://delba.io)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -22,17 +22,24 @@
 //  SOFTWARE.
 //
 
-public enum PermissionType {
-    case Contacts
-    case AddressBook // Deprecated in iOS 9.0
-    case LocationAlways
-    case LocationWhenInUse
-    case Notifications
-    case Microphone
-    case Camera
-    case Photos
-    case Reminders
-    case Events
-    case Bluetooth
-    case Motion
+import AddressBook
+
+// MARK: - AddressBook
+
+internal extension Permission {
+    var statusAddressBook: PermissionStatus {
+        let status = ABAddressBookGetAuthorizationStatus()
+        
+        switch status {
+        case .Authorized:          return .Authorized
+        case .Restricted, .Denied: return .Denied
+        case .NotDetermined:       return .NotDetermined
+        }
+    }
+    
+    func requestAddressBook(callback: Callback) {
+        ABAddressBookRequestAccessWithCompletion(nil) { _,_ in
+            callback(self.statusAddressBook)
+        }
+    }
 }

--- a/Source/PermissionTypes/Contacts.swift
+++ b/Source/PermissionTypes/Contacts.swift
@@ -22,7 +22,6 @@
 //  SOFTWARE.
 //
 
-import AddressBook
 import Contacts
 
 // MARK: - Contacts
@@ -38,13 +37,7 @@ internal extension Permission {
             case .NotDetermined:       return .NotDetermined
             }
         } else {
-            let status = ABAddressBookGetAuthorizationStatus()
-            
-            switch status {
-            case .Authorized:          return .Authorized
-            case .Restricted, .Denied: return .Denied
-            case .NotDetermined:       return .NotDetermined
-            }
+            fatalError()
         }
     }
     
@@ -54,9 +47,7 @@ internal extension Permission {
                 callback(self.statusContacts)
             }
         } else {
-            ABAddressBookRequestAccessWithCompletion(nil) { _,_ in
-                callback(self.statusContacts)
-            }
+            fatalError()
         }
     }
 }


### PR DESCRIPTION
I add AddressBook Type separately from Contacts since there is the possibility that we still need to use it on iOS9 even it's deprecated..
