### PR TITLE
Issue with didRequestPermission and Location request

### DIFF
--- a/Source/PermissionTypes/Location.swift
+++ b/Source/PermissionTypes/Location.swift
@@ -30,7 +30,6 @@ extension Permission: CLLocationManagerDelegate {
     public func locationManager(manager: CLLocationManager, didChangeAuthorizationStatus status: CLAuthorizationStatus) {
         if requestedLocation {
             callbacks(self.status)
-            requestedLocation = false
         }
     }
     


### PR DESCRIPTION
Set requestedLocation to false is creating issue here.
In fact didRequestPermission is called only once when the permission alert is displayed.
By removing this line, the delegate is called too when the user chooses
to accept or refuse the location service. Now this feature has the same behavior as the others permission requests. 

I don’t know if requestedLocation becomes useless or not with this
update, so I prefer to not remove it.

I hope it helps and thanks for your awesome project :)
