### PR TITLE
Added description property to the PermissionStatus enumeration

### DIFF
--- a/Source/PermissionStatus.swift
+++ b/Source/PermissionStatus.swift
@@ -30,10 +30,8 @@ public enum PermissionStatus {
     
     public var description: String {
         switch self {
-        case .authorized: return "Authorized"
-        case .denied: return "Denied"
-        case .disabled: return "Disabled"
         case .notDetermined: return "Not Determined"
+        default: return String(describing: self).capitalized
         }
     }
 }

--- a/Source/PermissionStatus.swift
+++ b/Source/PermissionStatus.swift
@@ -28,7 +28,7 @@ public enum PermissionStatus {
     case disabled
     case notDetermined
     
-    var description: String {
+    public var description: String {
         switch self {
         case .authorized: return "Authorized"
         case .denied: return "Denied"

--- a/Source/PermissionStatus.swift
+++ b/Source/PermissionStatus.swift
@@ -27,4 +27,13 @@ public enum PermissionStatus {
     case denied
     case disabled
     case notDetermined
+    
+    var description: String {
+        switch self {
+        case .authorized: return "Authorized"
+        case .denied: return "Denied"
+        case .disabled: return "Disabled"
+        case .notDetermined: return "Not Determined"
+        }
+    }
 }


### PR DESCRIPTION
This makes it something like this:

```
switch status {
case .authorized: print("Permission access: authorized")
case .denied: print("Permission access: denied")
case .disabled: print("Permission access: disabled")
case .notDetermined: print("Permission access: not determined")
}
```

To be generalized to something like:

```
print("Permission access: \(status.description))
```
