### PR TITLE
Pretty capitalization

### DIFF
--- a/Source/Permission.swift
+++ b/Source/Permission.swift
@@ -223,7 +223,7 @@ extension Permission {
         case .notifications:
             return "Notifications"
         default:
-            return String(describing: type)
+            return String(describing: type).capitalized
         }
     }
     

--- a/Source/PermissionStatus.swift
+++ b/Source/PermissionStatus.swift
@@ -28,7 +28,7 @@ public enum PermissionStatus {
     case disabled
     case notDetermined
     
-    var description: String {
+    public var description: String {
         switch self {
         case .authorized: return "Authorized"
         case .denied: return "Denied"

--- a/Source/PermissionStatus.swift
+++ b/Source/PermissionStatus.swift
@@ -27,4 +27,13 @@ public enum PermissionStatus {
     case denied
     case disabled
     case notDetermined
+    
+    var description: String {
+        switch self {
+        case .authorized: return "Authorized"
+        case .denied: return "Denied"
+        case .disabled: return "Disabled"
+        case .notDetermined: return "Not Determined"
+        }
+    }
 }

--- a/Source/PermissionTypes/Bluetooth.swift
+++ b/Source/PermissionTypes/Bluetooth.swift
@@ -32,17 +32,26 @@ internal let BluetoothManager = CBPeripheralManager(
 
 extension Permission {
     var statusBluetooth: PermissionStatus {
-        let state = (BluetoothManager.state, CBPeripheralManager.authorizationStatus())
+        let status = CBPeripheralManager.authorizationStatus()
         
-        switch state {
-        case (.unsupported, _), (.poweredOff, _), (_, .restricted):
+        switch status {
+        case .notDetermined:
+            return .notDetermined;
+        case .restricted:
             return .disabled
-        case (.unauthorized, _), (_, .denied):
+        case .denied:
             return .denied
-        case (.poweredOn, .authorized):
-            return .authorized
-        default:
-            return .notDetermined
+        case .authorized:
+            let state = BluetoothManager.state
+            
+            switch state {
+            case .unknown, .resetting, .unsupported, .poweredOff:
+                return .disabled
+            case .unauthorized:
+                return .denied
+            case .poweredOn:
+                return .authorized
+            }
         }
     }
     

--- a/Source/PermissionTypes/Bluetooth.swift
+++ b/Source/PermissionTypes/Bluetooth.swift
@@ -61,7 +61,9 @@ extension Permission: CBPeripheralManagerDelegate {
 
 extension CBPeripheralManager {
     func request(_ permission: Permission) {
-        startAdvertising(nil)
-        stopAdvertising()
+        if self.state == .poweredOn {
+            startAdvertising(nil)
+            stopAdvertising()
+        }
     }
 }


### PR DESCRIPTION
This capitalizes the `prettyDescription` property of each `Permission`.

Fixes the current inconsistency of only `Location` and `Notifications` being capitalized with all others lowercase.
