### PR TITLE
Pretty description capitalization

### DIFF
--- a/Source/Permission.swift
+++ b/Source/Permission.swift
@@ -223,7 +223,7 @@ extension Permission {
         case .notifications:
             return "Notifications"
         default:
-            return String(describing: type)
+            return String(describing: type).capitalized
         }
     }
     


### PR DESCRIPTION
This capitalizes the `prettyDescription` property of each `Permission`.

Fixes the current inconsistency of only `Location` and `Notifications` being capitalized with all others lowercase.
