### PR TITLE
Cocoapods permission configuration

### DIFF
--- a/Permission.podspec
+++ b/Permission.podspec
@@ -19,16 +19,6 @@ Pod::Spec.new do |s|
     co.source_files = "Source/**/*.{swift, h}"
   end
 
-  s.subspec 'Contacts' do |cn|
-    cn.dependency 'Permission/Core'
-    cn.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_CONTACTS" }
-  end
-
-  s.subspec 'Notifications' do |no|
-    no.dependency 'Permission/Core'
-    no.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_NOTIFICATIONS" }
-  end
-
   s.subspec 'AddressBook' do |ab|
     ab.dependency 'Permission/Core'
     ab.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_ADDRESS_BOOK" }
@@ -37,6 +27,16 @@ Pod::Spec.new do |s|
   s.subspec 'Bluetooth' do |bl|
     bl.dependency 'Permission/Core'
     bl.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_BLUETOOTH" }
+  end
+
+  s.subspec 'Camera' do |cm|
+    cm.dependency 'Permission/Core'
+    cm.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_CAMERA" }
+  end
+
+  s.subspec 'Contacts' do |cn|
+    cn.dependency 'Permission/Core'
+    cn.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_CONTACTS" }
   end
 
   s.subspec 'Events' do |ev|
@@ -57,6 +57,11 @@ Pod::Spec.new do |s|
   s.subspec 'Motion' do |mo|
     mo.dependency 'Permission/Core'
     mo.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_MOTION" }
+  end
+
+  s.subspec 'Notifications' do |no|
+    no.dependency 'Permission/Core'
+    no.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_NOTIFICATIONS" }
   end
 
   s.subspec 'Photos' do |ph|

--- a/Permission.podspec
+++ b/Permission.podspec
@@ -11,7 +11,72 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "8.0"
 
-  s.source_files = "Source/**/*.{swift, h}"
-
   s.requires_arc = true
+
+  s.default_subspec = 'Core'
+
+  s.subspec 'Core' do |co|
+    co.source_files = "Source/**/*.{swift, h}"
+  end
+
+  s.subspec 'Contacts' do |cn|
+    cn.dependency 'Permission/Core'
+    cn.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_CONTACTS" }
+  end
+
+  s.subspec 'Notifications' do |no|
+    no.dependency 'Permission/Core'
+    no.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_NOTIFICATIONS" }
+  end
+
+  s.subspec 'AddressBook' do |ab|
+    ab.dependency 'Permission/Core'
+    ab.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_ADDRESS_BOOK" }
+  end
+
+  s.subspec 'Bluetooth' do |bl|
+    bl.dependency 'Permission/Core'
+    bl.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_BLUETOOTH" }
+  end
+
+  s.subspec 'Events' do |ev|
+    ev.dependency 'Permission/Core'
+    ev.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_EVENTS" }
+  end
+
+  s.subspec 'Location' do |lo|
+    lo.dependency 'Permission/Core'
+    lo.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_LOCATION" }
+  end
+
+  s.subspec 'Microphone' do |mi|
+    mi.dependency 'Permission/Core'
+    mi.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_MICROPHONE" }
+  end
+
+  s.subspec 'Motion' do |mo|
+    mo.dependency 'Permission/Core'
+    mo.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_MOTION" }
+  end
+
+  s.subspec 'Photos' do |ph|
+    ph.dependency 'Permission/Core'
+    ph.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_PHOTOS" }
+  end
+
+  s.subspec 'Reminders' do |re|
+    re.dependency 'Permission/Core'
+    re.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_REMINDERS" }
+  end
+
+  s.subspec 'SpeechRecognizer' do |rs|
+    rs.dependency 'Permission/Core'
+    rs.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_SPEECH_RECOGNIZER" }
+  end
+
+  s.subspec 'MediaLibrary' do |ml|
+    ml.dependency 'Permission/Core'
+    ml.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_MEDIA_LIBRARY" }
+  end
+  
 end

--- a/Permission.podspec
+++ b/Permission.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "Permission"
-  s.version      = "1.5"
+  s.version      = "2.0"
   s.license      = { :type => "MIT" }
   s.homepage     = "https://github.com/delba/Permission"
   s.author       = { "Damien" => "damien@delba.io" }
   s.summary      = "A unified API to ask for permissions on iOS"
-  s.source       = { :git => "https://github.com/delba/Permission.git", :tag => "v1.5" }
+  s.source       = { :git => "https://github.com/delba/Permission.git", :tag => "v2.0" }
 
   s.weak_framework = 'Speech'
 
@@ -78,5 +78,5 @@ Pod::Spec.new do |s|
     ml.dependency 'Permission/Core'
     ml.pod_target_xcconfig = { "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSION_MEDIA_LIBRARY" }
   end
-  
+
 end

--- a/README.md
+++ b/README.md
@@ -231,13 +231,16 @@ You can install it with the following command:
 $ gem install cocoapods
 ```
 
-To integrate Permission into your Xcode project using CocoaPods, specify it in your `Podfile`:
+To integrate Permission into your Xcode project using CocoaPods, specify it in your `Podfile`. Due to Apple's new policy regarding permission access you need to specifically define what kind of permissions you want to access using subspecs. For example if you want to access the Camera and the Notifications you define the following:
 
 ```ruby
 use_frameworks!
 
-pod 'Permission'
+pod 'Permission/Camera'
+pod 'Permission/Notifications'
 ```
+
+Please see `Permission.podspec` for more information about which subspecs are available.
 
 ### Configuration
 


### PR DESCRIPTION
Made changes to the podspec file to allow configuration of the permission access using Cocoapods, without the need to define a seperate xcconfig file. This addresses issue #57.

Instead of defining the following in your podfile:
```
pod 'Permission'
```

You define specifically what permissions to access by using subspecs. For example like this:
```
pod 'Permission/Contacts'
pod 'Permission/Notifications'
```