### PR TITLE
Fix callback for Location

### DIFF
--- a/Source/PermissionTypes/Location.swift
+++ b/Source/PermissionTypes/Location.swift
@@ -25,7 +25,7 @@
 #if PERMISSION_LOCATION
 import CoreLocation
 
-internal let LocationManager = CLLocationManager()
+internal var LocationManager: CLLocationManager?
 
 private var requestedLocation = false
 private var triggerCallbacks  = false
@@ -51,6 +51,7 @@ extension CLLocationManager {
         delegate = permission
         
         requestedLocation = true
+        triggerCallbacks  = false
         
         if case .locationAlways = permission.type {
             requestAlwaysAuthorization()

--- a/Source/PermissionTypes/LocationAlways.swift
+++ b/Source/PermissionTypes/LocationAlways.swift
@@ -50,7 +50,8 @@ internal extension Permission {
             UserDefaults.standard.requestedLocationAlwaysWithWhenInUse = true
         }
         
-        LocationManager.request(self)
+        LocationManager = CLLocationManager()
+        LocationManager?.request(self)
     }
 }
 #endif

--- a/Source/PermissionTypes/LocationWhenInUse.swift
+++ b/Source/PermissionTypes/LocationWhenInUse.swift
@@ -44,7 +44,8 @@ internal extension Permission {
             return
         }
         
-        LocationManager.request(self)
+        LocationManager = CLLocationManager()
+        LocationManager?.request(self)
     }
 }
 #endif


### PR DESCRIPTION
This pull request may resolve https://github.com/delba/Permission/issues/122

`didChangeAuthorization` is called twice when the CLLocationManager instance is created and authorization status is changed. The mechanism handled by `requestedLocation ` and `triggerCallbacks` is based on this behavior.
So CLLocationManager instance must be created at the time of requesting authorization.